### PR TITLE
fix(firebase): remove old auth method compat code

### DIFF
--- a/src/services/database/firebase/firebase.ts
+++ b/src/services/database/firebase/firebase.ts
@@ -17,8 +17,6 @@ firebase.initializeApp({
 
 require("firebase/firestore");
 
-const FIREBASE_AUTH_DOMAIN = `renproject.io`;
-
 type DbTimestamps = {
   seconds: number;
   nanoseconds: number;
@@ -134,7 +132,6 @@ export class FireBase<Transaction extends { id: string }>
   ) => {
     const user = await getFirebaseUser(
       address,
-      FIREBASE_AUTH_DOMAIN,
       signatures
     );
     return (

--- a/src/services/database/firebase/firebaseUtils.ts
+++ b/src/services/database/firebase/firebaseUtils.ts
@@ -4,32 +4,25 @@ require("firebase/auth");
 require("firebase/firestore");
 require("firebase/functions");
 
-// Creates a user profile that is used for authenticating provision
-// to transaction records
-// FIXME: don't think this approach really provides value as a user can only ever have one signature
+// Creates a user profile
 const createOrUpdateProfileData = async (
   db: firebase.firestore.Firestore,
-  signature: string,
   uid: string
 ) => {
   // update user collection
   const doc = db.collection("users").doc(uid);
   const docData = await doc.get();
   if (docData.exists) {
-    const data = docData.data();
-    if (data && data.signatures.indexOf(signature) < 0) {
-      // add a new signature if needed
-      await doc.update({
-        signatures: data.signatures.concat([signature]),
-        updated: firebase.firestore.Timestamp.fromDate(new Date(Date.now())),
-      });
-    }
+    // add a new signature if needed
+    await doc.update({
+      updated: firebase.firestore.Timestamp.fromDate(new Date(Date.now())),
+    });
   } else {
     // create user
     await doc.set({
       uid,
       updated: firebase.firestore.Timestamp.fromDate(new Date(Date.now())),
-      signatures: [signature],
+      signatures: [],
     });
   }
 };
@@ -38,13 +31,13 @@ const createOrUpdateProfileData = async (
 // otherwise attempt to register
 const signInOrRegister = async (
   id: string,
-  signatures: { rawSignature: string; signature: string }
+  signature: string,
 ): Promise<firebase.User | null> => {
   let token: string | null = null;
   try {
     const res = await firebase.functions().httpsCallable("authenticate")({
-      signed: signatures.rawSignature,
-      account: id.split("@")[0],
+      signed: signature,
+      account: id,
     });
 
     token = res.data.token;
@@ -52,35 +45,21 @@ const signInOrRegister = async (
       throw new Error("missing token");
     }
   } catch (e) {
-    console.log("No token auth, falling back to email / sig");
+    console.error("Failed to authenticate with token", e);
   }
 
   let user;
   try {
-    user = token
-      ? (await firebase.auth().signInWithCustomToken(token)).user
-      : (
-          await firebase
-            .auth()
-            .signInWithEmailAndPassword(id, signatures.signature)
-        ).user;
+    user = token && (await firebase.auth().signInWithCustomToken(token)).user
   } catch (e) {
     // FIXME: we should probably handle wrong signatures here, as it would imply
     // some sort of corruption or attack.
     console.error(e);
-    if (e.message.includes("There is no user record")) {
-      user = (
-        await firebase
-          .auth()
-          .createUserWithEmailAndPassword(id, signatures.signature)
-      )?.user;
-    }
   }
   if (!user) return null;
   // always create / update profile data
   await createOrUpdateProfileData(
     firebase.firestore(),
-    signatures.signature,
     user.uid
   );
   return user;
@@ -88,21 +67,19 @@ const signInOrRegister = async (
 
 // Check if the user is currently authenticated for the correct address,
 // otherwise attempt to sign in or register for that address
+// TODO: remove "signature" and only rely on "rawSignature" because
+// only rawSignature can be verified
 export const getFirebaseUser = async (
   address: string,
-  host: string,
   signatures: { rawSignature: string; signature: string }
 ) => {
-  const accountEmailAddress = `${address.toLowerCase()}@${host}`;
-  console.log("id", address);
   const { currentUser } = firebase.auth();
 
   if (
     !currentUser ||
-    (currentUser.email && currentUser.email !== accountEmailAddress) ||
-    (!currentUser.email && currentUser.uid !== address)
+    (currentUser.uid !== address)
   ) {
-    return signInOrRegister(accountEmailAddress, signatures);
+    return signInOrRegister(address, signatures.rawSignature);
   } else {
     return currentUser;
   }


### PR DESCRIPTION
We used to use email + hashed signature for auth. This was untenable
because there was no guarentee that the hashed signature was
reproducable.

We moved to using a verifiable signature + cloud function to verify the
signature to check that a wallet signed the message; but had to support
both methods in order to migrate users.

This removes the migration code that was present in the previous implementation.


----

#