### PR TITLE
feat(fe): Make nonce reproduceable

### DIFF
--- a/src/features/mint/mintUtils.ts
+++ b/src/features/mint/mintUtils.ts
@@ -34,7 +34,12 @@ type CreateMintTransactionParams = {
   userAddress: string;
   destAddress: string;
   network: RenNetwork;
+  dayIndex: number;
 };
+
+export const getSessionDay = () => Math.floor(Date.now() / 1000 / 60 / 60 / 24);
+export const getSessionExpiry = () =>
+  (getSessionDay() + 1) * 60 * 60 * 24 * 1000;
 
 export const createMintTransaction = ({
   amount,
@@ -43,10 +48,11 @@ export const createMintTransaction = ({
   userAddress,
   destAddress,
   network,
+  dayIndex,
 }: CreateMintTransactionParams) => {
   // Providing a nonce manually prevents us from needing to instantiate the mint-machine just for that purpose
   // It does not need to be truely random, because it is already limited by destination address
-  const nonce = Math.floor(Math.random() * 10 ** 16);
+  const nonce = dayIndex + getSessionDay();
   const tx: GatewaySession = {
     id: "tx-" + nonce,
     type: "mint",
@@ -57,8 +63,8 @@ export const createMintTransaction = ({
     destChain: getChainRentxName(mintedCurrencyChain),
     targetAmount: Number(amount),
     userAddress,
-    nonce: nonce.toString(16).padEnd(64, "0"),
-    expiryTime: new Date().getTime() + 1000 * 60 * 60 * 24,
+    nonce: nonce.toString(16).padStart(64, "0"),
+    expiryTime: getSessionExpiry(),
     transactions: {},
     customParams: {},
   };

--- a/src/features/mint/steps/MintFeesStep.tsx
+++ b/src/features/mint/steps/MintFeesStep.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../../components/layout/Paper";
 import { CenteredProgress } from "../../../components/progress/ProgressHelpers";
 import { TooltipWithIcon } from "../../../components/tooltips/TooltipWithIcon";
+import { useTransactionEntryStyles } from "../../../components/transactions/TransactionsGrid";
 import {
   AssetInfo,
   BigAssetAmount,
@@ -56,6 +57,7 @@ import { findExchangeRate } from "../../marketData/marketDataUtils";
 import { $renNetwork } from "../../network/networkSlice";
 import { TransactionFees } from "../../transactions/components/TransactionFees";
 import {
+  $currentSessionCount,
   addTransaction,
   setCurrentTxId,
 } from "../../transactions/transactionsSlice";
@@ -95,6 +97,7 @@ export const MintFeesStep: FunctionComponent<TxConfigurationStepProps> = ({
     signatures: { signature },
   } = useSelector($wallet);
   const network = useSelector($renNetwork);
+  const currentSessionCount = useSelector($currentSessionCount);
   const exchangeRates = useSelector($exchangeRates);
   const { fees, pending } = useFetchFees(currency, TxType.MINT);
   const currencyUsdRate = findExchangeRate(exchangeRates, currency);
@@ -130,6 +133,7 @@ export const MintFeesStep: FunctionComponent<TxConfigurationStepProps> = ({
     setAckChecked(event.target.checked);
   }, []);
   useShakePaper(showAckError);
+
   const tx = useMemo(
     () =>
       createMintTransaction({
@@ -140,6 +144,7 @@ export const MintFeesStep: FunctionComponent<TxConfigurationStepProps> = ({
         mintedCurrencyChain: chain,
         userAddress: account,
         network: network,
+        dayIndex: currentSessionCount,
       }),
     [amount, currency, account, chain, network]
   );

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -1,7 +1,13 @@
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { GatewaySession } from "@renproject/ren-tx";
 import { RootState } from "../../store/rootReducer";
-import { getLockAndMintParams } from "../mint/mintUtils";
+import { getCurrencyRentxName } from "../../utils/assetConfigs";
+import { $mint } from "../mint/mintSlice";
+import {
+  getLockAndMintParams,
+  getSessionDay,
+  getSessionExpiry,
+} from "../mint/mintUtils";
 import { $renNetwork } from "../network/networkSlice";
 import { getBurnAndReleaseParams } from "../release/releaseUtils";
 import { txCompletedSorter, TxEntryStatus, TxType } from "./transactionsUtils";
@@ -101,6 +107,20 @@ export const $networkTransactions = createSelector(
 export const $orderedTransactions = createSelector(
   $networkTransactions,
   (txs) => [...txs].sort(txCompletedSorter)
+);
+
+export const $currentSessionCount = createSelector(
+  $networkTransactions,
+  $mint,
+  (txs, mint) => {
+    const expiryTime = getSessionExpiry();
+    return [...txs].filter(
+      (x) =>
+        x.sourceAsset == getCurrencyRentxName(mint.currency) &&
+        x.type == "mint" &&
+        x.expiryTime === expiryTime
+    ).length;
+  }
 );
 
 //TODO: move this one to separate file to simplify up store dependencies (chunks)


### PR DESCRIPTION
This allows for mint transactions to be restored if the user knows the (UTC) day they initiated the mint, as well as the number of mints they previously initiated that day.

Ultimately, it means that even if transaction persistence is lost, we can still help users recover sent funds