### PR TITLE
fix(history): Handle intermediate expiry states

### DIFF
--- a/src/features/mint/steps/MintProcessStep.tsx
+++ b/src/features/mint/steps/MintProcessStep.tsx
@@ -62,6 +62,7 @@ import {
   createTxQueryString,
   getAddressExplorerLink,
   getTxPageTitle,
+  isTxExpired,
   parseTxQueryString,
   TxType,
   useTxParam,
@@ -404,7 +405,16 @@ const MintTransactionStatus: FunctionComponent<MintTransactionStatusProps> = ({
       ) : (
         <MintDepositToStatus tx={current.context.tx} />
       )}
-      {timeRemained <= 0 && <ExpiredErrorDialog open onAction={onRestart} />}
+      {
+        // We want to allow users to finish mints for deposits that have been detected
+        // If there are no deposits, and the gateway is expired (timeRemained < 0),
+        // show the expiry modal
+        (isTxExpired(current.context.tx) ||
+          (timeRemained <= 0 &&
+            Object.keys(current.context.tx.transactions).length === 0)) && (
+          <ExpiredErrorDialog open onAction={onRestart} />
+        )
+      }
       <WrongAddressWarningDialog
         open={wrongAddressDialogOpened}
         address={account}


### PR DESCRIPTION
The current model is to have 48 hours of gateway validity with an
additional 24 hours for minting. The current implementation will
show an expiry error in the 24 hours minting grace period, breaking
the flow.

This fixes that by only showing the expiry warning when there are
no detected deposits for the given gateway.

It still has an unfortunate state where the "semi-expired" transactions
show as pending, but we will leave this for fixing after release