### PR TITLE
hotfix: disable releasing to luna + fil from solana

### DIFF
--- a/src/components/dropdowns/AssetDropdown.tsx
+++ b/src/components/dropdowns/AssetDropdown.tsx
@@ -33,12 +33,21 @@ const getOptions = (mode: AssetDropdownMode) => {
 const getOptionBySymbol = (symbol: string, mode: AssetDropdownMode) =>
   getOptions(mode).find((option) => option.symbol === symbol);
 
-const createAvailabilityFilter = (available: Array<string> | undefined) => (
-  option: BridgeChainConfig | BridgeCurrencyConfig
-) => {
+const createAvailabilityFilter = (
+  available: Array<string> | undefined,
+  chain?: BridgeChain
+) => (option: BridgeChainConfig | BridgeCurrencyConfig) => {
+  console.log(available, option, chain);
   if (!available) {
     return true;
   }
+  if (
+    chain === BridgeChain.SOLC &&
+    (option.symbol === "RENLUNA" || option.symbol === "RENFIL")
+  ) {
+    return false;
+  }
+
   return available.includes(option.symbol);
 };
 
@@ -98,6 +107,7 @@ type AssetDropdownProps = SelectProps & {
   available?: Array<BridgeCurrency | BridgeChain>;
   balances?: Array<AssetBalance>;
   condensed?: boolean;
+  chain?: BridgeChain;
   label?: string;
 };
 
@@ -130,8 +140,8 @@ export const AssetDropdown: FunctionComponent<AssetDropdownProps> = ({
   const styles = useAssetDropdownStyles();
   const condensedSelectClasses = useCondensedSelectStyles();
   const availabilityFilter = useMemo(
-    () => createAvailabilityFilter(available),
-    [available]
+    () => createAvailabilityFilter(available, rest.chain),
+    [available, rest.chain]
   );
   const valueRenderer = useMemo(
     () => (value: any) => {

--- a/src/features/release/steps/ReleaseInitialStep.tsx
+++ b/src/features/release/steps/ReleaseInitialStep.tsx
@@ -28,6 +28,8 @@ import {
 } from "../../../components/typography/TypographyHelpers";
 import { releaseChainClassMap } from "../../../services/rentx";
 import {
+  BridgeChain,
+  BridgeCurrency,
   getChainConfig,
   getCurrencyConfig,
   supportedBurnChains,
@@ -154,6 +156,10 @@ export const ReleaseInitialStep: FunctionComponent<TxConfigurationStepProps> = (
   } else {
     enabled = basicCondition;
   }
+  enabled = !(
+    chain == BridgeChain.SOLC &&
+    [BridgeCurrency.RENLUNA, BridgeCurrency.RENFIL].includes(currency)
+  );
   const showMinimalAmountError =
     walletConnected && hasDefinedAmount && !hasMinimalAmount && !pending;
 
@@ -212,6 +218,7 @@ export const ReleaseInitialStep: FunctionComponent<TxConfigurationStepProps> = (
         <AssetDropdownWrapper>
           <AssetDropdown
             label="Asset"
+            chain={chain}
             available={supportedReleaseCurrencies}
             balances={balances}
             value={currency}


### PR DESCRIPTION
Currently there is an issue with passing release addresses to renvm. This prevents new releases from being created until a ren-js fix is pushed