### PR TITLE
remove fixed height to fix the lang modal UI issue

### DIFF
--- a/src/features/i18n/components/I18nHelpers.tsx
+++ b/src/features/i18n/components/I18nHelpers.tsx
@@ -138,7 +138,7 @@ export const LanguageSelector: FunctionComponent<LanguageSelectorProps> = ({
           title={t("languages.choose-language")}
           onClose={handleClose}
         >
-          <SpacedPaperContent topPadding bottomPadding fixedHeight>
+          <SpacedPaperContent topPadding bottomPadding>
             {resolvedAvailableLocales.map((languageKey) => (
               <LanguageButtonWrapper key={languageKey}>
                 <LanguageButton


### PR DESCRIPTION
fixed height will make the modal look weird. one issue is for Windows Users there is a scroll bar to fail border-radius, another one is there is no correct padding-bottom inside the modal. I think removing it is an easy way to fix it. If need a fixed height modal later, can try to make the scrollable area inside the modal.