### PR TITLE
change correct value to cal decimal place

### DIFF
--- a/src/features/gateway/steps/GatewayFeesStep.tsx
+++ b/src/features/gateway/steps/GatewayFeesStep.tsx
@@ -275,7 +275,7 @@ export const GatewayFeesStep: FunctionComponent<GatewayStepProps> = ({
               <NumberFormatText
                 value={outputAmount}
                 spacedSuffix={assetLabel}
-                decimalScale={feesDecimalImpact(amount)}
+                decimalScale={feesDecimalImpact(activeAmount)}
               />
             }
             valueEquivalent={


### PR DESCRIPTION
The value given to decimalScale={feesDecimalImpact(amount)} is the wrong one, so the decimal place will not be related to the mint amount.