### PR TITLE
fix white screen on Metamask mobile

### DIFF
--- a/src/features/notifications/notificationsUtils.ts
+++ b/src/features/notifications/notificationsUtils.ts
@@ -32,7 +32,7 @@ export const useBrowserNotifications = (onEnabled = () => {}) => {
   return {
     enabled,
     handleEnable,
-    Notification,
+    // Notification,
     showBrowserNotification,
   };
 };


### PR DESCRIPTION
There has an issue when I open the bridge page on MetaMask mobile version.
The issue was created by other few months ago:
https://github.com/renproject/bridge-v2/issues/130

I found that there is no Notification object on MetaMask mobile, and the Notification where I was commented is not used by anywhere, so I think we can remove it and it can be used on MetaMask mobile version.